### PR TITLE
Update xtensa-lx-rt to 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/esp-rs/xtensa-atomic-emulation-trap"
 edition = "2021"
 
 [dependencies]
-xtensa-lx-rt = "0.13.0"
+xtensa-lx-rt = "0.14.0"
 
 # TODO is this needed?
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ extern "C" {
     fn __user_exception(cause: ExceptionCause, save_frame: &mut Context);
 }
 
-#[link_section = ".rwtext"]
 #[export_name = "__exception"] // this overrides the exception handler in xtensa_lx_rt
 #[link_section = ".rwtext"]
 unsafe fn exception(cause: ExceptionCause, save_frame: &mut Context) {


### PR DESCRIPTION
In order to prepare a small change in esp-hal ( https://github.com/esp-rs/xtensa-lx-rt/pull/50 ) we first need to update all its dependencies

I also removed a duplicate `#[link_section = ".rwtext"]` since the compiler got angry about it - don't know if that was some needed tricky thing I don't know of or if it was just redundant 🤷‍♂️ 

We'll also need a release then