### PR TITLE
Use `u32` instead of `usize` where applicable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xtensa-atomic-emulation-trap"
 version = "0.3.0"
 description = "An atomic emulation trap handler for non atomic Xtensa targets."
-keywords = ["Xtensa", "emulation", "atomic"]
+keywords = ["xtensa", "emulation", "atomic"]
 authors = ["Scott Mabin <scott@mabez.dev>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/esp-rs/xtensa-atomic-emulation-trap"
@@ -11,9 +11,6 @@ edition = "2021"
 [dependencies]
 xtensa-lx-rt = "0.14.0"
 
-# TODO is this needed?
 [features]
-esp32   = ["xtensa-lx-rt/esp32"]
 esp32s2 = ["xtensa-lx-rt/esp32s2"]
-esp32s3 = ["xtensa-lx-rt/esp32s3"]
 esp8266 = ["xtensa-lx-rt/esp8266"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtensa-atomic-emulation-trap"
-version = "0.3.0"
+version = "0.3.1"
 description = "An atomic emulation trap handler for non atomic Xtensa targets."
 keywords = ["xtensa", "emulation", "atomic"]
 authors = ["Scott Mabin <scott@mabez.dev>"]


### PR DESCRIPTION
This will hopefully solve the issues of the `esp32s2-hal` documentation failing to build.

I've also removed the `esp32` and `esp32s3` features, as these devices both natively support atomics and as such do not require emulation.